### PR TITLE
Fix empflix in videodevil for Raspberry Pi

### DIFF
--- a/plugin.video.videodevil/videodevil.py
+++ b/plugin.video.videodevil/videodevil.py
@@ -893,7 +893,11 @@ class CCurrentList:
                 return
             data = handle.read()
             #cj.save(os.path.join(resDir, 'cookies.lwp'), ignore_discard=True)
-            cj.save(cookiePath)
+            try:
+                cj.save(cookiePath)
+            except ValueError:
+                if enable_debug:
+                    xbmc.log('Failed to save the cookie jar, expire time out of bounds')
             current_url_page = curr_url
             if enable_debug:
                 f.write(data)


### PR DESCRIPTION
Fixes the Value error at the start up of empflix and hardsextube on Raspberry Pi platform.

The issue:
- Launch VideoDevil >> scroll to empflix >> hit enter key
- Expected: empflix view is shown
- Current: empflix view is not shown, the following error dialog window is shown instead
  "VideoDevil Error
  Error running VideoDevil.
  Reason:
  ValueError: timestamp out of range for platform time_t"

Cause:
The cookies expire date set by empflix and hardsextube websites are too big for the Raspberry Pi platform.
(https://en.wikipedia.org/wiki/Year_2038_problem)

Reproduced on platform:
- Hardware: Raspberry PI B-1
- OS: Raspbmc, version: raspbmc-rls-1.0-hardfp-b20130208-u20150125
- Kodi version: 14.1 Git:2015-02-02-81c4046-dirty Media Center Kodi
- Videodevil version: 1.7.104

Traceback (most recent call last):
  File "/home/pi/.kodi/addons/plugin.video.videodevil/videodevil.py", line 1520, in run
    if self.parseView(currentView) == 0:
  File "/home/pi/.kodi/addons/plugin.video.videodevil/videodevil.py", line 1358, in parseView
    result = self.currentlist.loadLocal(url, lItem = lItem)
  File "/home/pi/.kodi/addons/plugin.video.videodevil/videodevil.py", line 818, in loadLocal
    self.loadRemote(self.start, False, lItem)
  File "/home/pi/.kodi/addons/plugin.video.videodevil/videodevil.py", line 896, in loadRemote
    cj.save(cookiePath)
  File "/usr/lib/python2.7/_LWPCookieJar.py", line 89, in save
    f.write(self.as_lwp_str(ignore_discard, ignore_expires))
  File "/usr/lib/python2.7/_LWPCookieJar.py", line 75, in as_lwp_str
    r.append("Set-Cookie3: %s" % lwp_cookie_str(cookie))
  File "/usr/lib/python2.7/_LWPCookieJar.py", line 35, in lwp_cookie_str
    time2isoz(float(cookie.expires))))
  File "/usr/lib/python2.7/cookielib.py", line 99, in time2isoz
    year, mon, mday, hour, min, sec = time.gmtime(t)[:6]
ValueError: timestamp out of range for platform time_t

Cookies value:
Set-Cookie3: content_filter="type%3Dtranny%2Cgay%26filter%3Dcams"; path="/"; domain="www.empflix.com"; path_spec; expires="2097-06-14 23:35:11Z"; version=0
Set-Cookie3: PHPSESSID=86hg6qgqs0h620stk19p8ds065; path="/"; domain=".hardsextube.com"; path_spec; domain_dot; expires="2060-11-27 22:43:50Z"; version=0
