### PR TITLE
Fixing data18-content

### DIFF
--- a/metadata.movie.data18.content.com/addon.xml
+++ b/metadata.movie.data18.content.com/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.movie.data18.content.com"
        name="Data 18 Web Content"
-       version="1.6.0"
+       version="1.7.0"
        provider-name="xbmc-adult">
   <requires>
     <import addon="xbmc.metadata" version="1.0"/>

--- a/metadata.movie.data18.content.com/data18.content.xml
+++ b/metadata.movie.data18.content.com/data18.content.xml
@@ -1,19 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><scraper framework="1.1" date="2015-07-01" name="Data18Content" content="movies" language="en">
 	<CreateSearchUrl clearbuffers="no" dest="14">
-		<RegExp input="$INFO[search_engine]" output="$$3" dest="14">
+		<RegExp input="$INFO[data18_search_engine]" output="$$3" dest="14">
 			<RegExp input="$$5" output="&lt;url&gt;\1&lt;/url&gt;" dest="3">
 				<!--Add film year, stored in $$2 for default by xbmc-->
-				<RegExp input="$$2" output=" (\1)" dest="4">
-					<expression clear="yes">(.+)</expression>
-				</RegExp>
-			<RegExp input="$$1" output="http://www.google.com/search?q=\1+site%3Adata18.com%2Fcontent&amp;btnG=Search&amp;output=search" dest="5">
+				<RegExp input="$$1" output="http://www.google.com/search?q=\1+site%3Adata18.com%2Fcontent" dest="5">
 					<expression />
 				</RegExp>
 				<expression noclean="1" />
 			</RegExp>
 			<expression>Google</expression>
 		</RegExp>
-		<RegExp input="$INFO[search_engine]" output="$$3" dest="14">
+		<RegExp input="$INFO[data18_search_engine]" output="$$3" dest="14">
 			<RegExp input="$$5" output="&lt;url&gt;\1&lt;/url&gt;" dest="3">
 				<!--Add film year, stored in $$2 for default by xbmc-->
 				<RegExp input="$$2" output=" (\1)" dest="4">
@@ -26,8 +23,8 @@
 			</RegExp>
 			<expression>Bing</expression>
 		</RegExp>
-		<RegExp input="$INFO[search_engine]" output="$$3" dest="14">
-			<RegExp input="$$1" output="&lt;url&gt;http://www.data18.com/search/?k=\1&amp;b=1&amp;t=0&lt;/url&gt;" dest="3">
+		<RegExp input="$INFO[data18_search_engine]" output="$$3" dest="14">
+			<RegExp input="$$1" output="&lt;url&gt;http://www.data18.com/search/?k=\1&amp;b=1&amp;t=0&lt;url&gt;" dest="3">
 				<expression noclean="1" />
 			</RegExp>
 			<expression>Data18</expression>
@@ -35,11 +32,11 @@
 	</CreateSearchUrl>
 	<NfoUrl dest="3">
 		<RegExp input="$$1" output="&lt;details&gt;&lt;url&gt;\1&lt;/url&gt;&lt;/details&gt;" dest="3">
-			<expression noclean="1">(data18.com/content/[^\.]+\.html)</expression>
+			<expression noclean="1">(data18.com/content/\d+)</expression>
 		</RegExp>
 	</NfoUrl>
 	<GetSearchResults clearbuffers="no" dest="16">
-		<RegExp input="$INFO[search_engine]" output="$$6" dest="16">
+		<RegExp input="$INFO[data18_search_engine]" output="$$6" dest="16">
 			<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results sorted=&quot;yes&quot;&gt;\1&lt;/results&gt;" dest="6">
 				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;\1&lt;/url&gt;&lt;/entity&gt;" dest="4+">
 					<expression repeat="yes" noclean="1">&lt;h3 class="r"&gt;&lt;a href="/url\?q=([^&amp;]+)&amp;(?:[^&gt;]*)&gt;(.+?)&lt;/a&gt;&lt;/h3&gt;</expression>
@@ -48,19 +45,19 @@
 			</RegExp>
 			<expression>Google</expression>
 		</RegExp>
-		<RegExp input="$INFO[search_engine]" output="$$6" dest="16">
+		<RegExp input="$INFO[data18_search_engine]" output="$$6" dest="16">
 			<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results sorted=&quot;yes&quot;&gt;\1&lt;/results&gt;" dest="6">
 				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;\1&lt;/url&gt;&lt;/entity&gt;" dest="4+">
-					<expression repeat="yes" noclean="1">&lt;div class=&quot;b_title&quot;&gt;&lt;h2&gt;&lt;a href=&quot;([^&quot;]*)&quot;(?:.+?)&gt;(.+?)&lt;/a&gt;&lt;/h2&gt;</expression>
+					<expression repeat="yes" noclean="1">&lt;h2&gt;&lt;a href=&quot;([^&quot;]*)&quot;(?:.+?)&gt;(.+?)&lt;/a&gt;&lt;/h2&gt;</expression>
 				</RegExp>
 				<expression noclean="1" />
 			</RegExp>
 			<expression>Bing</expression>
 		</RegExp>
-		<RegExp input="$INFO[search_engine]" output="$$6" dest="16">
-			<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results&gt;\1&lt;/results&gt;" dest="6">
+		<RegExp input="$INFO[data18_search_engine]" output="$$6" dest="16">
+			<RegExp input="$$4" output="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;yes&quot;?&gt;&lt;results sorted=&quot;yes&quot;&gt;\1&lt;/results&gt;" dest="6">
 				<RegExp input="$$1" output="&lt;entity&gt;&lt;title&gt;\2&lt;/title&gt;&lt;url&gt;http://www.data18.com/content/\1&lt;/url&gt;&lt;/entity&gt;" dest="4+">
-					<expression repeat="yes" noclean="1">&lt;a href="http://www.data18.com/content/([^"]+)"&gt;([^&lt;]+)&lt;/a&gt;&lt;/p&gt;</expression>
+					<expression repeat="yes" noclean="1">&lt;a href="http://www.data18.com/content/([^"]+)" class="bold"&gt;([^&lt;]+)&lt;/a&gt;&lt;/span&gt;&lt;/p&gt;</expression>
 				</RegExp>
 				<expression noclean="1" />
 			</RegExp>
@@ -109,6 +106,9 @@
 			<!--This isn't usually listed on web clips-->
 			<RegExp input="$$1" output="&lt;director&gt;\1&lt;/director&gt;" dest="5+">
 				<expression trim="1">Director:&lt;/b&gt;[^&gt;]*&gt;([^&lt;]*)</expression>
+			</RegExp>
+			<RegExp input="$$1" output="&lt;premiered&gt;\1-\2-\3&lt;/premiered&gt;" dest="5+">
+				<expression trim="1">Release Date: &lt;a href="http://www.data18.com/content/date-(\d{4})(\d{2})(\d{2}).html</expression>
 			</RegExp>
 			<!--Studio is the network the clip is from-->
 			<RegExp input="$$1" output="&lt;studio&gt;\1&lt;/studio&gt;" dest="5+">
@@ -183,23 +183,23 @@
 			</RegExp>
 			<!--fanart-->
 			<RegExp input="$$13" output="\1" dest="5+">
-				<!-- Images from gallery - not working (almost?) all the time -->
-				<RegExp input="$$1" output="&lt;url spoof=&quot;http://www.data18.com&quot; function=&quot;GetFanartFromViewer&quot;&gt;\1&lt;/url&gt;" dest="13+">
-					<expression>&lt;a href="(http://www.data18.com/viewer/[^/]+/01)?" rel="nofollow"&gt;</expression>
-				</RegExp>
-				<RegExp input="$$1" output="&lt;url spoof=&quot;http://www.data18.com&quot; function=&quot;GetFanartFromViewer&quot;&gt;\1&lt;/url&gt;" dest="13+">
-					<expression>&lt;a href="(http://www.data18.com/viewer/[^/]+/02)?" rel="nofollow"&gt;</expression>
-				</RegExp>
-				<!-- horizontal image available without spoofing (e.g. http://www.data18.com/content/174268)-->
-				<RegExp input="$$1" output="&lt;fanart&gt;&lt;thumb spoof=&quot;http://www.data18.com&quot;&gt;http://\1/\2/\3/\4/hor.jpg&lt;/thumb&gt;&lt;/fanart&gt;" dest="13+">
-					<expression>img src="http://([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^0-9]+)?([0-9]+).jpg"  alt="image</expression>
-				</RegExp>
-				<!--Gets photo linked by trailer. This is fallback in case there is no image gallery. This will get replaced by the previous expressions if possible, because the image galleries are higher resolution.-->
+				<!--Gets photo linked by trailer. This is fallback in case there is no image gallery. This will get replaced by the following expressions if possible, because the image galleries are higher resolution.-->
 				<!-- e.g. http://www.data18.com/content/1103871 -->
-				<RegExp input="$$1" output="&lt;fanart&gt;&lt;thumb spoof=&quot;http://www.data18.com&quot;&gt;\1&lt;/thumb&gt;&lt;/fanart&gt;" dest="13+">
+				<RegExp input="$$1" output="&lt;fanart&gt;&lt;thumb spoof=&quot;http://www.data18.com&quot;&gt;\1&lt;/thumb&gt;&lt;/fanart&gt;" dest="13">
 					<expression>img src="([^"]+)" style="[^"]+" alt="[^"]+" [^&lt;]+&lt;a [^&gt;]+title="Play this Video"</expression>
 				</RegExp>
-
+				<!-- horizontal image available without spoofing (e.g. http://www.data18.com/content/174268)-->
+				<RegExp input="$$1" output="&lt;fanart&gt;&lt;thumb spoof=&quot;http://www.data18.com&quot;&gt;http://\1/\2/\3/\4/hor.jpg&lt;/thumb&gt;&lt;/fanart&gt;" dest="13">
+					<expression>img src="http://([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^0-9]+)?([0-9]+).jpg" alt="image</expression>
+				</RegExp>
+				<!-- Images from gallery -->
+				<RegExp input="$$1" output="&lt;url spoof=&quot;http://www.data18.com&quot; function=&quot;GetFanartFromViewer&quot;&gt;\1&lt;/url&gt;" dest="13">
+					<expression>&lt;a href="(http://www.data18.com/viewer/[^/]+/01)?" rel="nofollow"&gt;</expression>
+				</RegExp>
+				<!--On some pages the first photo gallery link goes to image 2 instead of image 1-->
+				<RegExp input="$$1" output="&lt;url spoof=&quot;http://www.data18.com&quot; function=&quot;GetFanartFromViewer&quot;&gt;\1&lt;/url&gt;" dest="13">
+					<expression>&lt;a href="(http://www.data18.com/viewer/[^/]+/02)?" rel="nofollow"&gt;</expression>
+				</RegExp>
 				<expression noclean="1" />
 			</RegExp>
 			<!--Actors with new format-->
@@ -225,7 +225,8 @@
 	</GetPhotoFromViewer>
 	<GetFanartFromViewer dest="3">
 		<RegExp input="$$5" output="&lt;details&gt;\1&lt;/details&gt;" dest="3">
-			<RegExp input="$$1" output="&lt;fanart url=&quot;http://\1/\2/\3/\4/\5&quot; spoof=&quot;http://www.data18.com/viewer/&quot;&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;01.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;02.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;03.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;04.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;05.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;06.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;07.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;08.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;09.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;10.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;11.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;12.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;13.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;14.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;15.jpg&lt;/thumb&gt;&lt;/fanart&gt;" dest="5">
+			<!-- Try and Use 3rd or 2nd image first so poster and fanart don't have the same image -->
+			<RegExp input="$$1" output="&lt;fanart url=&quot;http://\1/\2/\3/\4/\5&quot; spoof=&quot;http://www.data18.com/viewer/&quot;&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;03.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;02.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;01.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;04.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;05.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;06.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;07.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;08.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;09.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;10.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;11.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;12.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;13.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;14.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;15.jpg&lt;/thumb&gt;&lt;thumb spoof=&quot;http://www.data18.com/viewer/&quot;&gt;16.jpg&lt;/thumb&gt;&lt;/fanart&gt;" dest="5">
 				<expression trim="5" noclean="1,2,3,4,5">&lt;img src="http://([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^0-9]+)?([0-9]+).jpg" class="noborder" alt="image" /&gt;</expression>
 			</RegExp>
 			<expression noclean="1" />

--- a/metadata.movie.data18.content.com/resources/settings.xml
+++ b/metadata.movie.data18.content.com/resources/settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
   <category label="Search Setting">
-    <setting label="40000" type="select" id="search_engine" values="Google|Bing|Data18" default="Google"/>
+    <setting label="40000" type="select" id="data18_search_engine" values="Google|Bing|Data18" default="Bing"/>
   </category>
 </settings>


### PR DESCRIPTION
Bunch of fixes for data18-content:
- Fixed Google, Bing, and data18 search sources. 
- Fixed a name collision which was always causing Google search to occur even if Bing or data18 was set.
- Set Bing as default search engine because Google will temporarily return 503's after a few requests, and data18 requires exact title matches
- Fanart retrieval was not working properly, and was only getting the single (low quality) video preview image, no matter how many higher quality sample images exist.
- Poster uses first sample image, and fanart will use 3rd (if available) so that you don't see the same image for both.
- Fixed local nfo retrieval
