### PR TITLE
Fix not playing. Unsupported protocol (http:http)

### DIFF
--- a/plugin.video.empflix/addon.py
+++ b/plugin.video.empflix/addon.py
@@ -66,7 +66,7 @@ def PLAYVIDEO(url):
         link = openURL('http:' + configurl)
         match2 = re.compile('<videoLink>([^<]+)</videoLink>').findall(link)
         if match2:
-            xbmc.Player().play('http:' + match2[-1])
+            xbmc.Player().play(match2[-1])
 
 
 def get_params():


### PR DESCRIPTION
Videos are not playing due to malformed url passed to the player.
My solution is to skip concatenating http: to the link.
