### PR TITLE
Fix Videodevil Space Order

### DIFF
--- a/plugin.video.videodevil/videodevil.py
+++ b/plugin.video.videodevil/videodevil.py
@@ -849,7 +849,7 @@ class CCurrentList:
                                       ).replace('\\"', '\"')
         if info_name == 'title':
             try:
-                info_value = clean_safe(info_value.strip())
+                info_value = clean_safe(info_value.lstrip(' -@#$%^&*_-+=.,\';:"\|/?`~>)]}!').rstrip())
             except:
                 info_value = '...'
             if len(info_value) == 0:


### PR DESCRIPTION
When items with non-letter, non-space characters they are displaced
before items that start with a space. This causes videos to be displayed
before Categories, Sort, Next Page and Search icons. Striping these
characters from the left side of the string text fixes this issue. I am
not sure if its necessary to do the same to .curr section
