### PR TITLE
Porntrex: Fix 'next' in category

### DIFF
--- a/plugin.video.videodevil/resources/porntrex.com.cfg
+++ b/plugin.video.videodevil/resources/porntrex.com.cfg
@@ -59,16 +59,16 @@ item_info_name=icon
 item_info_build=video.devil.image|next.png
 item_url_build=https://www.porntrex.com/%s
 ########################################################
-item_infos=<li class="next"><a href="#videos".+?data-parameters=".+?from:([\d]+)">
-item_order=url
+item_infos=<link\s*href="([^"]+)"\s*rel="canonical"[^^]+class="next"><a\s*href="#[^;]+;from:(\d+)
+item_order=url|url.append
 item_skill=space|lock
-item_info_name=url
+item_info_name=url.append
 item_info_build=?from=%s
 item_info_name=title
 item_info_build=video.devil.locale|30103
 item_info_name=icon
 item_info_build=video.devil.image|next.png
-item_url_build=https://www.porntrex.com/%s
+item_url_build=%s
 ########################################################
 item_infos=<li class="next"><a href="#search".+?data-parameters="q:([^;]+).+?from_albums:([\d]+)">
 item_order=url|url.append


### PR DESCRIPTION
While my previous commit 485b79d0b2913db4e3658281f0ce59e738115d2d fixed  #176, I broke **next** in _Categories_ that send to **next** of general pages
This should restore it back.