### PR TITLE
Porntrex: fixes

### DIFF
--- a/plugin.video.videodevil/resources/porntrex.com.cfg
+++ b/plugin.video.videodevil/resources/porntrex.com.cfg
@@ -7,7 +7,7 @@ catcher=porntrex.com
 ########################################################
 # Videos
 ########################################################
-item_infos=class="video-item.+?href="([^"]+)"\s*title="([^"]+).+?original="([^"]+).+?clock[^\d]+([\d:]+)
+item_infos=class="video-item thumb-item\s+">.+?href="([^"]+)"\s*title="([^"]+).+?original="([^"]+).+?clock[^\d]+([\d:]+)
 item_order=url|title|icon|title.append
 item_info_name=icon
 item_info_build=https://www.porntrex.com%s

--- a/plugin.video.videodevil/resources/porntrex.com.cfg
+++ b/plugin.video.videodevil/resources/porntrex.com.cfg
@@ -10,7 +10,7 @@ catcher=porntrex.com
 item_infos=class="video-item thumb-item\s+">.+?href="([^"]+)"\s*title="([^"]+).+?original="([^"]+).+?clock[^\d]+([\d:]+)
 item_order=url|title|icon|title.append
 item_info_name=icon
-item_info_build=https://www.porntrex.com%s
+item_info_build=http:%s
 item_info_name=title.append
 item_info_build= (%s)
 item_info_name=type


### PR DESCRIPTION
- Follow up of #182. This time is it should properly skip _Private_ videos, while keeping access to regular videos.
- Fix url for video thumbnails 