### PR TITLE
Update videodevil.py

### DIFF
--- a/plugin.video.videodevil/videodevil.py
+++ b/plugin.video.videodevil/videodevil.py
@@ -1292,6 +1292,8 @@ class Main(object):
                                      m_icon,
                                      len(self.currentlist.items),
                                      m)
+        # Force Wall viewmode
+        xbmc.executebuiltin('Container.SetViewMode(500)')                    
         return result
 
     def addListItem(self, title, url, icon, totalItems, lItem):


### PR DESCRIPTION
force Wall viewmode. Looks much nicer to have a thumbnail view as a default for this kind of content instead of text-lists. Tested with Estuary skin and it works fine and makes this plugin much nicer to use.