### PR TITLE
fix next button for groups on motherless

### DIFF
--- a/plugin.video.videodevil/resources/motherless.com.groups.cfg
+++ b/plugin.video.videodevil/resources/motherless.com.groups.cfg
@@ -24,7 +24,7 @@ item_url_build=https://motherless.com/gv/%s
 ########################################################
 # Next
 ########################################################
-item_infos=<a href="([^"]+)" class="pop" rel="[^"]+">NEXT
+item_infos=<a href="([^"]+)" class="pop" rel="next">
 item_order=url
 item_skill=space|lock
 item_info_name=title


### PR DESCRIPTION
Fixes next button in groups on motherless 
as mentioned in 
https://github.com/xbmc-adult/xbmc-adult/issues/422#issuecomment-889558156