### PR TITLE
(VideoDevil) Fix user agent

### DIFF
--- a/plugin.video.videodevil/videodevil.py
+++ b/plugin.video.videodevil/videodevil.py
@@ -35,7 +35,7 @@ imgDir = os.path.join(resDir, 'images')
 urlopen = urllib_request.urlopen
 cj = http_cookiejar.LWPCookieJar()
 Request = urllib_request.Request
-USERAGENT = 'Mozilla/5.0 (Windows; U; Windows NT 5.2; en-GB; rv:1.8.1.18) Gecko/20081029 Firefox/2.0.0.18'
+USERAGENT = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/118.0'
 
 if cj:
     if os.path.isfile(TRANSLATEPATH(cookiePath)):

--- a/plugin.video.videodevil/videodevil.py
+++ b/plugin.video.videodevil/videodevil.py
@@ -1188,6 +1188,8 @@ class Main(object):
                 xbmc.log('Play: ' + str(flv_file), INFO)
             xbmc.Player().play(str(flv_file), listitem)
         else:
+            # Provide useragent string to player
+            url += '|User-Agent=%s' % USERAGENT
             if enable_debug:
                 xbmc.log('Play: ' + str(url), INFO)
             xbmc.Player().play(str(url), listitem)


### PR DESCRIPTION
This PR Fixes/updates the user agent string.
The old string used a (very) outdated browser version.
I also added passing the user agent string to the player.

Fixes https://github.com/xbmc-adult/xbmc-adult/issues/456 (and maybe some other ones as well)

Testversion:
[plugin.video.videodevil-99.8.27.zip](https://github.com/xbmc-adult/xbmc-adult/files/12909707/plugin.video.videodevil-99.8.27.zip)
